### PR TITLE
printing a plant now prints the plants name

### DIFF
--- a/plants/plant.py
+++ b/plants/plant.py
@@ -63,3 +63,6 @@ class Plant(Identifiable):
             self.__required_locations.append(location)
         else:
             raise TypeError("location must be a string.")
+
+    def __str__(self):
+        return self.name


### PR DESCRIPTION
# Description

When you print a plant instance, it now prints the plant's name, like `Silversword (ef217f9a)`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

git fetch --all
git checkout rc-operation-poison-ivy
notice and adore the __str__ method in plant.py



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
