### PR TITLE
Rc max plants

### DIFF
--- a/actions/get_plant_biomes.py
+++ b/actions/get_plant_biomes.py
@@ -9,12 +9,16 @@ def get_plant_biomes(plant, arboretum):
     '''
     plant_biomes = []
 
-    allowed_biomes = plant.required_locations
+    required_biomes = plant.required_locations
     all_biomes = arboretum.biomes
-    for biome in allowed_biomes:
-        for key, value in all_biomes.items():
-            if key == biome:
-                # add biomes to plant_biomes list
-                plant_biomes.extend(all_biomes[key])
+    for required_biome in required_biomes:
+        for potential_biome, value in all_biomes.items():
+            # if the biome in the arboretum is in required biomes of given plant
+            if potential_biome == required_biome:
+                for biome in all_biomes[potential_biome]:
+                    # check each biome to make sure it is not full
+                    if not biome.is_plants_full():
+                        # add biomes to plant_biomes list
+                        plant_biomes.append(biome)
             
     return plant_biomes

--- a/actions/get_plant_biomes.py
+++ b/actions/get_plant_biomes.py
@@ -13,12 +13,15 @@ def get_plant_biomes(plant, arboretum):
     all_biomes = arboretum.biomes
     for required_biome in required_biomes:
         for potential_biome, value in all_biomes.items():
-            # if the biome in the arboretum is in required biomes of given plant
+            # Checking to see if the category of biome in the arboretum
+            # is an acceptable category for what the plant requires
             if potential_biome == required_biome:
                 for biome in all_biomes[potential_biome]:
-                    # check each biome to make sure it is not full
+                    # Check each biome to make sure it is not full. This
+                    # prevents users from over-populating a biome with plants.
                     if not biome.is_plants_full():
                         # add biomes to plant_biomes list
                         plant_biomes.append(biome)
-            
+                        
+    # Return list of acceptable biomes.
     return plant_biomes

--- a/actions/show_plant_biomes.py
+++ b/actions/show_plant_biomes.py
@@ -16,7 +16,9 @@ def show_plant_biomes(plant, biome_list):
     if biome_list:
         print('Cultivate Plant \n \n')
         for index, biome in enumerate(biome_list):
-            print(f'{index + 1}. {biome.name} ( plants)')
+            # Example menu:     1. Forest (0 plants)
+            #                   2. Forest (2 plants)
+            print(f'{index + 1}. {biome.name} ({len(biome.plants)} plants)')
         
         choice = input(f'''\nWhere would you like to cultivate the {plant.species}?
 Type M to return to the main menu. > ''')

--- a/index.py
+++ b/index.py
@@ -30,6 +30,7 @@ from animals import (
 )
 
 
+
 keahua = Arboretum("Keahua Arboretum", "123 Paukauila Lane")
 
 # os.system("say Welcome to Arboretum!" if os.name != "nt" else "cls")

--- a/interfaces/habitat/contains_plants.py
+++ b/interfaces/habitat/contains_plants.py
@@ -11,5 +11,5 @@ class IContainsPlants:
     def maximum_plants(self):
         return self.__maximum_plants
 
-    def is_plants_full():
+    def is_plants_full(self):
         return len(self.plants) >= self.__maximum_plants


### PR DESCRIPTION
# Description

When a user wants to cultivate a plant, they are now only presented a menu that contains biomes that are:
- In the Arboretum 
- Acceptable for the given plant's requirements
- Not maxed out on plants

Fixes #29 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing Instructions

add and commit your current branch
`git checkout master`
`git fetch --all`
`git checkout rc-max-plants`
`python index.py`
experiment with adding plants before adding biomes, or adding plants to biomes you've created. 



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
