### PR TITLE
Lr fixing river

### DIFF
--- a/actions/release_animal.py
+++ b/actions/release_animal.py
@@ -171,10 +171,10 @@ def release_animal(arboretum):
         else: 
             Kikakapu_habitats = list()
             for river in arboretum.rivers:
-                if len(river.animals) < 2:
+                if len(river.animals) < 12:
                     Kikakapu_habitats.append(river)
             for swamp in arboretum.swamps:
-                if len(swamp.animals) < 2:
+                if len(swamp.animals) < 8:
                     Kikakapu_habitats.append(swamp)
             if Kikakapu_habitats != []:
                 for index, place in enumerate(Kikakapu_habitats):
@@ -210,26 +210,36 @@ def release_animal(arboretum):
             input("\n\nPress enter to continue...")
 
         else: 
-            new_list = arboretum.grasslands + arboretum.forests
-            for index, place in enumerate(new_list):
-                print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
-            print("Release the animal into which biome?")
-            choice5 = input("> ")
-            try: 
-                selection = new_list[int(choice5) - 1].id
-                forest = list(filter(lambda x: x.id == selection, arboretum.forests))
-                grassland = list(filter(lambda x: x.id == selection, arboretum.grasslands))
+            pueo_habitats = list()
+            for land in arboretum.grasslands:
+                if len(land.animals) < 22:
+                    pueo_habitats.append(land)
+            for forest in arboretum.forests:
+                if len(forest.animals) < 20:
+                    pueo_habitats.append(forest)
+            if pueo_habitats != []:
+                for index, place in enumerate(pueo_habitats):
+                    print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
+                print("Release the animal into which biome?")
+                choice5 = input("> ")
+                try: 
+                    selection = pueo_habitats[int(choice5) - 1].id
+                    forest = list(filter(lambda x: x.id == selection, arboretum.forests))
+                    grassland = list(filter(lambda x: x.id == selection, arboretum.grasslands))
 
-                if grassland != []:
-                    grassland[0].add_animal(animal)
-                if forest != []: 
-                    forest[0].add_animal(animal)
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                    if grassland != []:
+                        grassland[0].add_animal(animal)
+                    if forest != []: 
+                        forest[0].add_animal(animal)
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    release_animal(arboretum)
+            else: 
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                release_animal(arboretum)
-
 
 
     if choice == "6":
@@ -263,26 +273,36 @@ def release_animal(arboretum):
             input("\n\nPress enter to continue...")
 
         else: 
-            new_list = arboretum.mountains + arboretum.forests
-            for index, place in enumerate(new_list):
-                print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
-            print("Release the animal into which biome?")
-            choice7 = input("> ")
-            try: 
-                selection = new_list[int(choice7) - 1].id
-                forest = list(filter(lambda x: x.id == selection, arboretum.forests))
-                mountain = list(filter(lambda x: x.id == selection, arboretum.mountains))
+            Opeapea_habitats = list()
+            for mountain in arboretum.mountains:
+                if len(mountain.animals) < 2:
+                    Opeapea_habitats.append(mountain)
+            for forest in arboretum.forests:
+                if len(forest.animals) < 2:
+                    Opeapea_habitats.append(forest)
+            if Opeapea_habitats != []:
+                for index, place in enumerate(Opeapea_habitats):
+                    print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
+                print("Release the animal into which biome?")
+                choice7 = input("> ")
+                try: 
+                    selection = Opeapea_habitats[int(choice7) - 1].id
+                    forest = list(filter(lambda x: x.id == selection, arboretum.forests))
+                    mountain = list(filter(lambda x: x.id == selection, arboretum.mountains))
 
-                if mountain != []:
-                    mountain[0].add_animal(animal)
-                if forest != []: 
-                    forest[0].add_animal(animal)
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                    if mountain != []:
+                        mountain[0].add_animal(animal)
+                    if forest != []: 
+                        forest[0].add_animal(animal)
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    release_animal(arboretum)
+            else: 
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                release_animal(arboretum)
-
 
     if choice == "8":
         os.system("cls" if os.name == "nt" else "clear")

--- a/actions/release_animal.py
+++ b/actions/release_animal.py
@@ -87,6 +87,7 @@ def release_animal(arboretum):
         else: 
             gecko_habitats = list()
             for forest in arboretum.forests:
+                # if the biome has less than 20 animal in it, add it to the list
                 if len(forest.animals) < 20:
                     gecko_habitats.append(forest)
             if gecko_habitats != []:
@@ -98,9 +99,11 @@ def release_animal(arboretum):
                 choice2 = input("> ")
 
                 try:
+                    # capture the selection 
                     selection = gecko_habitats[int(choice2) - 1].id
-                    # append the animal to the biome list
+                    # filter the aboretum.forest list for the selection
                     forest = list(filter(lambda x: x.id == selection, arboretum.forests))
+                    # append the animal to the biome list
 
                     forest[0].add_animal(animal)
                     # clear screen and print success message
@@ -326,7 +329,7 @@ def release_animal(arboretum):
         else: 
             spider_habitats = list()
             for swamp in arboretum.swamps:
-                if len(swamp.animals) < 8:
+                if len(swamp.animals) < 8≈:
                     spider_habitats.append(swamp)
             if spider_habitats != []:
 

--- a/actions/release_animal.py
+++ b/actions/release_animal.py
@@ -87,9 +87,8 @@ def release_animal(arboretum):
         else: 
             gecko_habitats = list()
             for forest in arboretum.forests:
-                if len(forest.animals) < 2:
+                if len(forest.animals) < 20:
                     gecko_habitats.append(forest)
-                    print("append!")
             if gecko_habitats != []:
                 # loop over the biomes and display them in terminal
                 for index, forest in enumerate(gecko_habitats):
@@ -99,8 +98,11 @@ def release_animal(arboretum):
                 choice2 = input("> ")
 
                 try:
+                    selection = gecko_habitats[int(choice2) - 1].id
                     # append the animal to the biome list
-                    arboretum.forests[int(choice2) - 1].add_animal(animal)
+                    forest = list(filter(lambda x: x.id == selection, arboretum.forests))
+
+                    forest[0].add_animal(animal)
                     # clear screen and print success message
                     os.system("cls" if os.name == "nt" else "clear")
                     print(F'Success! The {animal.species} has been added to the biome!')
@@ -124,22 +126,36 @@ def release_animal(arboretum):
             print("Uh Oh! There are no biomes for this animal to live in. Please go create a biome for this animal.")
             input("\n\nPress enter to continue...")
         else: 
-            # loop over the biomes and display them in terminal
-            for index, grassland in enumerate(arboretum.grasslands):
-                print(f'{index + 1}. Grassland ({len(grassland.animals)} animals)')
-            print("Release the animal into which biome?")
+            nenegoose_habitats = list()
+            for land in arboretum.grasslands:
+                if len(land.animals) < 22:
+                    nenegoose_habitats.append(land)
+            if nenegoose_habitats != []:
+                # loop over the biomes and display them in terminal
+                for index, grassland in enumerate(nenegoose_habitats):
+                    print(f'{index + 1}. Grassland ({len(grassland.animals)} animals)')
+                print("Release the animal into which biome?")
 
-            choice3 = input("> ")
+                choice3 = input("> ")
 
-            try: 
-                # append the animal to the biome list
-                arboretum.grasslands[int(choice3) - 1].add_animal(animal)
-                # clear screen and print success message
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                try: 
+                    selection = nenegoose_habitats[int(choice3) - 1].id
+                    # append the animal to the biome list
+                    land = list(filter(lambda x: x.id == selection, arboretum.grasslands))
+
+                    land[0].add_animal(animal)
+                    # append the animal to the biome list
+                    arboretum.grasslands[int(choice3) - 1].add_animal(animal)
+                    # clear screen and print success message
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    release_animal(arboretum)
+            else: 
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                release_animal(arboretum)
 
 
 
@@ -153,25 +169,36 @@ def release_animal(arboretum):
             input("\n\nPress enter to continue...")
 
         else: 
-            new_list = arboretum.rivers + arboretum.swamps
-            for index, place in enumerate(new_list):
-                print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
-            print("Release the animal into which biome?")
-            choice4 = input("> ")
-            try: 
-                selection = new_list[int(choice4) - 1].id
-                swamp = list(filter(lambda x: x.id == selection, arboretum.swamps))
-                river = list(filter(lambda x: x.id == selection, arboretum.rivers))
+            Kikakapu_habitats = list()
+            for river in arboretum.rivers:
+                if len(river.animals) < 2:
+                    Kikakapu_habitats.append(river)
+            for swamp in arboretum.swamps:
+                if len(swamp.animals) < 2:
+                    Kikakapu_habitats.append(swamp)
+            if Kikakapu_habitats != []:
+                for index, place in enumerate(Kikakapu_habitats):
+                    print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
+                print("Release the animal into which biome?")
+                choice4 = input("> ")
+                try: 
+                    selection = Kikakapu_habitats[int(choice4) - 1].id
+                    swamp = list(filter(lambda x: x.id == selection, arboretum.swamps))
+                    river = list(filter(lambda x: x.id == selection, arboretum.rivers))
 
-                if river != []:
-                    river[0].add_animal(animal)
-                if swamp != []: 
-                    swamp[0].add_animal(animal)
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                    if river != []:
+                        river[0].add_animal(animal)
+                    if swamp != []: 
+                        swamp[0].add_animal(animal)
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    release_animal(arboretum)
+            else: 
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                release_animal(arboretum)
 
 
     if choice == "5":

--- a/actions/release_animal.py
+++ b/actions/release_animal.py
@@ -250,19 +250,31 @@ def release_animal(arboretum):
             print("Uh Oh! There are no biomes for this animal to live in. Please go create a biome for this animal.")
             input("\n\nPress enter to continue...")
         else: 
-            for index, coastline in enumerate(arboretum.coastlines):
-                print(f'{index + 1}. Coastline ({len(coastline.animals)} animals)')
-            print("Release the animal into which biome?")
+            ulae_habitats = list()
+            for coast in arboretum.coastlines:
+                if len(coast.animals) < 15:
+                    ulae_habitats.append(coast)
+            if ulae_habitats != []:
+                for index, coastline in enumerate(ulae_habitats):
+                    print(f'{index + 1}. Coastline ({len(coastline.animals)} animals)')
+                print("Release the animal into which biome?")
 
-            choice6 = input("> ")
-            try: 
-                arboretum.coastlines[int(choice6) - 1].add_animal(animal)
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                choice6 = input("> ")
+                try: 
+                    selection = ulae_habitats[int(choice6) - 1].id
+                    # append the animal to the biome list
+                    coast = list(filter(lambda x: x.id == selection, arboretum.coastlines))
+
+                    coast[0].add_animal(animal)
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    release_animal(arboretum)
+            else: 
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                release_animal(arboretum)
-
 
     if choice == "7":
         os.system("cls" if os.name == "nt" else "clear")
@@ -275,10 +287,10 @@ def release_animal(arboretum):
         else: 
             Opeapea_habitats = list()
             for mountain in arboretum.mountains:
-                if len(mountain.animals) < 2:
+                if len(mountain.animals) < 6:
                     Opeapea_habitats.append(mountain)
             for forest in arboretum.forests:
-                if len(forest.animals) < 2:
+                if len(forest.animals) < 20:
                     Opeapea_habitats.append(forest)
             if Opeapea_habitats != []:
                 for index, place in enumerate(Opeapea_habitats):
@@ -312,17 +324,32 @@ def release_animal(arboretum):
             print("Uh Oh! There are no biomes for this animal to live in. Please go create a biome for this animal.")
             input("\n\nPress enter to continue...")
         else: 
-            for index, swamp in enumerate(arboretum.swamps):
-                print(f'{index + 1}. Swamp ({len(swamp.animals)} animals)')
-            print("Release the animal into which biome?")
+            spider_habitats = list()
+            for swamp in arboretum.swamps:
+                if len(swamp.animals) < 8:
+                    spider_habitats.append(swamp)
+            if spider_habitats != []:
 
-            choice8 = input("> ")
-            try:
-                arboretum.swamps[int(choice8) - 1].add_animal(animal)
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                for index, swamp in enumerate(spider_habitats):
+                    print(f'{index + 1}. Swamp ({len(swamp.animals)} animals)')
+                print("Release the animal into which biome?")
+
+                choice8 = input("> ")
+                try:
+                    selection = spider_habitats[int(choice8) - 1].id
+                    # append the animal to the biome list
+                    swamp = list(filter(lambda x: x.id == selection, arboretum.swamps))
+
+                    swamp[0].add_animal(animal)
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    release_animal(arboretum)
+            else: 
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                release_animal(arboretum)
+
 
 

--- a/actions/release_animal.py
+++ b/actions/release_animal.py
@@ -329,7 +329,7 @@ def release_animal(arboretum):
         else: 
             spider_habitats = list()
             for swamp in arboretum.swamps:
-                if len(swamp.animals) < 8≈:
+                if len(swamp.animals) < 8:
                     spider_habitats.append(swamp)
             if spider_habitats != []:
 

--- a/actions/release_animal.py
+++ b/actions/release_animal.py
@@ -31,33 +31,48 @@ def release_animal(arboretum):
             input("\n\nPress enter to continue...")
 
         else: 
+
             # combine the rivers and coastline lists
-            new_list = arboretum.rivers + arboretum.coastlines
+            new_list = []
+            for river in arboretum.rivers:
+                # add the river to the list if it has less than 12 animals in it
+                if len(river.animals) < 12:
+                    new_list.append(river)
+            for coast in arboretum.coastlines:
+                # add the coastline to the list if it has less than 15 animals in it
+                if len(coast.animals) < 15:
+                    new_list.append(coast)
+
+            if new_list != []:
             # loop over list and display in terminal
-            for index, place in enumerate(new_list):
-                print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
-            print("Release the animal into which biome?")
-            choice1 = input("> ")
-            try:
-                selection = new_list[int(choice1) - 1].id
-                # search the river list for the selection
-                river = list(filter(lambda x: x.id == selection, arboretum.rivers))
-                # search the coast list for the selection
-                coast = list(filter(lambda x: x.id == selection, arboretum.coastlines))
-                if river != []:
-                    # add the animal to the river that was found in the search
-                    river[0].add_animal(animal)
-                elif coast != []: 
-                    # add the animal to the river that was found in the search
-                    coast[0].add_animal(animal)
-                    # clear screen and print success message
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                for index, place in enumerate(new_list):
+                    print(f'{index + 1}. {place.name} ({len(place.animals)} animals)')
+                print("Release the animal into which biome?")
+                choice1 = input("> ")
+                try:
+                    selection = new_list[int(choice1) - 1].id
+                    # search the river list for the selection
+                    river = list(filter(lambda x: x.id == selection, arboretum.rivers))
+                    # search the coast list for the selection
+                    coast = list(filter(lambda x: x.id == selection, arboretum.coastlines))
+                    if river != []:
+                        # add the animal to the river that was found in the search
+                        river[0].add_animal(animal)
+                    elif coast != []: 
+                        # add the animal to the river that was found in the search
+                        coast[0].add_animal(animal)
+                        # clear screen and print success message
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    # re-load the release animal function if the user enters a choice that is not on the list
+                    release_animal(arboretum)
+            else:
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                # re-load the release animal function if the user enters a choice that is not on the list
-                release_animal(arboretum)
-        
+
             
 
 
@@ -70,22 +85,32 @@ def release_animal(arboretum):
             print("Uh Oh! There are no biomes for this animal to live in. Please go create a biome for this animal.")
             input("\n\nPress enter to continue...")
         else: 
-            # loop over the biomes and display them in terminal
-            for index, forest in enumerate(arboretum.forests):
-                print(f'{index + 1}. Forest ({len(forest.animals)} animals)')
-            print("Release the animal into which biome?")
+            gecko_habitats = list()
+            for forest in arboretum.forests:
+                if len(forest.animals) < 2:
+                    gecko_habitats.append(forest)
+                    print("append!")
+            if gecko_habitats != []:
+                # loop over the biomes and display them in terminal
+                for index, forest in enumerate(gecko_habitats):
+                    print(f'{index + 1}. Forest ({len(forest.animals)} animals)')
+                print("Release the animal into which biome?")
 
-            choice2 = input("> ")
+                choice2 = input("> ")
 
-            try:
-                # append the animal to the biome list
-                arboretum.forests[int(choice2) - 1].add_animal(animal)
-                 # clear screen and print success message
-                os.system("cls" if os.name == "nt" else "clear")
-                print(F'Success! The {animal.species} has been added to the biome!')
+                try:
+                    # append the animal to the biome list
+                    arboretum.forests[int(choice2) - 1].add_animal(animal)
+                    # clear screen and print success message
+                    os.system("cls" if os.name == "nt" else "clear")
+                    print(F'Success! The {animal.species} has been added to the biome!')
+                    input("\n\nPress enter to continue...")
+                except: 
+                    release_animal(arboretum)
+            else: 
+                # print this if there are biomes created but they are all full
+                print("Uh-oh! It looks like all of the biomes are full! Please go create a new Biome for this animal to live in.")
                 input("\n\nPress enter to continue...")
-            except: 
-                release_animal(arboretum)
 
 
 


### PR DESCRIPTION
# Description

User should be able to only add animals to biomes that are not full. If a biome is full, it should not show up on the list.

Fixes #36 (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Testing Instructions

1. `git fetch --all`
2. `git checkout lr-fixing-river`
3. Add a swamp biome and add 8 animals to it. When you add the 8th animal, try to go back and add a 9th, you should not see the swamp biome anymore. There is similar functionality for all of the other animals. User should be able to only add animals to biomes that are not full. If a biome is full, it should not show up on the list.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
