### PR TITLE
Removed stretch goals from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,23 +212,3 @@ Mountain [bdf33960]
 
 Press any key to continue...
 ```
-
-## Stretch Goals
-
-1. Display groups of things in each biome when you display the lists above.
-    ```html
-    1. Grassland (1 Silversword, 4 Blue Jade Vine, 4 Nene Goose)
-    ```
-2. Only show biomes that are able to store the number of animals/plants. For example, the user chooses to release a river dolphin and one of the river biomes is already at capacity.
-    ```sh
-    1. Mountain (5 plants)
-    2. River (12 animals)  <-- not a valid choice
-    3. Grassland (0 plants)
-    ```
-
-     Instead of showing all possible options, only show valid options.
-
-    ```sh
-    1. Mountain (5 plants)
-    2. Grassland (0 plants)
-    ```


### PR DESCRIPTION
# Description

No stretch goals on readme, that way the readme is directed towards users and not students building the app.

Fixes #53 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# Testing Instructions

No Mo Stretch Go



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
